### PR TITLE
reference bindings for db encryption - requires ee, so don't merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vendor/couchbase-lite-core-EE
 # Editors
 .vscode
 *.sublime-workspace
+.env
 
 # Python
 python/CouchbaseLite/*.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
-option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
+option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" ON)
 
 if(CMAKE_COMPILER_IS_GNUCC)
     # Suppress an annoying note about GCC 7 ABI changes

--- a/bindings/python/BuildPyCBL.py
+++ b/bindings/python/BuildPyCBL.py
@@ -197,16 +197,30 @@ typedef enum {
     kCBLDatabase_NoUpgrade     = 4,  ///< Disable upgrading an older-version database
 } CBLDatabaseFlags;
 
+typedef enum {
+    kCBLEncryptionNone = 0,
+    kCBLEncryptionAES256
+} CBLEncryptionAlgorithm;
+
+typedef enum {
+    kCBLEncryptionKeySizeAES256 = 32
+} CBLEncryptionKeySize;
+
+typedef struct {
+    CBLEncryptionAlgorithm algorithm;
+    uint8_t bytes[32];
+} CBLEncryptionKey;
+
 typedef struct {
     const char *directory;
     CBLDatabaseFlags flags;
-    ...;
+    CBLEncryptionKey* encryptionKey;
 } CBLDatabaseConfiguration;
 
 typedef struct {
     FLString directory;
     CBLDatabaseFlags flags;
-    ...;
+    CBLEncryptionKey* encryptionKey;
 } CBLDatabaseConfiguration_s;
 
 void CBLListener_Remove(CBLListenerToken*);

--- a/bindings/python/CouchbaseLite/Database.py
+++ b/bindings/python/CouchbaseLite/Database.py
@@ -23,7 +23,7 @@ from .common import *
 from .Document import *
 
 class DatabaseConfiguration:
-    def __init__(self, directory, create = True, readOnly = False, noUpgrade = False):
+    def __init__(self, directory, create = True, readOnly = False, noUpgrade = False, encryption_key = None):
         self.directory = directory
         self._flags = 0
         if create:
@@ -33,9 +33,15 @@ class DatabaseConfiguration:
         if noUpgrade:
             self._flags |= lib.kCBLDatabase_NoUpgrade
 
+        if encryption_key:
+            self._encryption_key = ffi.new("CBLEncryptionKey*", [lib.kCBLEncryptionAES256 , encryption_key])
+        else:
+            self._encryption_key = ffi.NULL
+
+
     def _cblConfig(self):
         self._cblDir = cstr(self.directory)  # to keep string from being GC'd
-        return ffi.new("CBLDatabaseConfiguration*", [self._cblDir, self._flags])
+        return ffi.new("CBLDatabaseConfiguration*", [self._cblDir, self._flags, self._encryption_key])
 
     def __repr__(self):
         return "DatabaseConfiguration['" + self.directory + "']"

--- a/bindings/python/test/test.py
+++ b/bindings/python/test/test.py
@@ -24,7 +24,9 @@ import json
 
 Database.deleteFile("db", "/tmp")
 
-db = Database("db", DatabaseConfiguration("/tmp"))
+key = bytes(32)
+print(key)
+db = Database("db", DatabaseConfiguration(directory="/tmp", encryption_key=key))
 
 print ("db   = ", db)
 print ("name = ", db.name)

--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,5 @@ mkdir -p build_cmake
 cd build_cmake
 
 core_count=`getconf _NPROCESSORS_ONLN`
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_ENTERPRISE=ON ..
 make -j `expr $core_count + 1`

--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -43,9 +43,9 @@ typedef CBL_OPTIONS(uint32_t, CBLDatabaseFlags) {
 /** Database encryption algorithms (available only in the Enterprise Edition). */
 typedef CBL_ENUM(uint32_t, CBLEncryptionAlgorithm) {
     kCBLEncryptionNone = 0,      ///< No encryption (default)
-#ifdef COUCHBASE_ENTERPRISE
+// #ifdef COUCHBASE_ENTERPRISE
     kCBLEncryptionAES256,        ///< AES with 256-bit key
-#endif
+// #endif
 };
 
 /** Encryption key sizes (in bytes). */


### PR DESCRIPTION
@bhtaulbee @sspivak reference for when we get ee build for db bindings. Will prob need to pass a flag to the constructor so this can work with & without encryption.

Don't merge, keep as reference for now